### PR TITLE
deps: update core and settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ readme = "README.md"
 requires-python = ">3.11"
 packages = [{include = "apis_ontology"}]
 dependencies = [
-    "apis-core-rdf==0.49.1",
-    "apis-acdhch-default-settings==2.10.0",
+    "apis-core-rdf==0.51.0",
+    "apis-acdhch-default-settings==2.12.0",
     "psycopg>=3.2.9",
     "psycopg2>=2.9.10",
     "faker>=37.5.3",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -21,27 +21,29 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.9.0"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/b4/636b3b65173d3ce9a38ef5f0522789614e590dab6a8d505340a4efe4c567/anyio-4.10.0.tar.gz", hash = "sha256:3f3fae35c96039744587aa5b8371e7e8e603c0702999535961dd336026973ba6", size = 213252, upload-time = "2025-08-04T08:54:26.451Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/12/e5e0282d673bb9746bacfb6e2dba8719989d3660cdb2ea79aee9a9651afb/anyio-4.10.0-py3-none-any.whl", hash = "sha256:60e474ac86736bbfd6f210f7a61218939c318f43f9972497381f1c5e930ed3d1", size = 107213, upload-time = "2025-08-04T08:54:24.882Z" },
 ]
 
 [[package]]
 name = "apis-acdhch-default-settings"
-version = "2.10.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "apis-acdhch-django-auditlog" },
     { name = "apis-core-rdf" },
     { name = "dj-database-url" },
     { name = "django" },
     { name = "django-allow-cidr" },
+    { name = "django-auditlog" },
     { name = "django-auth-ldap" },
     { name = "django-csp" },
     { name = "django-removals" },
@@ -55,18 +57,30 @@ dependencies = [
     { name = "requests" },
     { name = "whitenoise" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fa/c4/23e3fd2f7096d5d5dfa5728a9b7d6281925d93dc2a2e5b69edd2ac0d6134/apis_acdhch_default_settings-2.10.0.tar.gz", hash = "sha256:e904a54471c166441d1e8d09b4bfb52fd204fb46534ce61a210bc7f1da21f4f0", size = 13547, upload-time = "2025-06-10T14:48:53.835Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/96/8996be9cd6586dec2d6e100e77beb5f1459e02588c5c6f9c50facf4439b0/apis_acdhch_default_settings-2.12.0.tar.gz", hash = "sha256:687e3db5cfdbda9b4a2b29460b02fc2cbfe5cd3ba17b188d364f8c59ac122c25", size = 14285, upload-time = "2025-08-12T10:07:36.643Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/81/79f10dda997871e2f4c4ebd3c37d6c3c1e9c1edbf3d3077ba6b43264bc0c/apis_acdhch_default_settings-2.10.0-py3-none-any.whl", hash = "sha256:8204d6b5c5ec8b3c3bcd47dc524ebf280f8954ce0e0e882b558ef46f8214c9c6", size = 10061, upload-time = "2025-06-10T14:48:52.209Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b1/1042ea3f949e29ea64fc692a76e1a4f3163d92d6a318453d9666c41bd19c/apis_acdhch_default_settings-2.12.0-py3-none-any.whl", hash = "sha256:ec78f7f4f2272bba5b09e27ab3d56cd3d4d62d5efd937b3ac67136a5886a8cab", size = 10924, upload-time = "2025-08-12T10:07:35.202Z" },
+]
+
+[[package]]
+name = "apis-acdhch-django-auditlog"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "django-auditlog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/4b/a68ae24583aad89d687acae1f67571a45debec4c1b74099a53b51f790a97/apis_acdhch_django_auditlog-0.3.0.tar.gz", hash = "sha256:563b81bac6567f3ad060dba219f63397625784da43cb8a511753205c8a0e5bbb", size = 21213, upload-time = "2025-08-14T06:34:18.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/47/6c7e054e3667757c935919023f1398c1107f3414abfb20a9a7913bf3178b/apis_acdhch_django_auditlog-0.3.0-py3-none-any.whl", hash = "sha256:1d97090aad19c6266e4450c7b07cf59f253f5f80bb4ba263e0fbdb83159891ac", size = 5728, upload-time = "2025-08-14T06:34:17.535Z" },
 ]
 
 [[package]]
 name = "apis-core-rdf"
-version = "0.49.1"
+version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "acdh-arche-assets" },
-    { name = "crispy-bootstrap4" },
     { name = "crispy-bootstrap5" },
     { name = "django" },
     { name = "django-autocomplete-light" },
@@ -83,9 +97,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "tablib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a6/3f/a190fb1bb852a59a871343638e96d86ce6fc8605238311ab8af15b355ca1/apis_core_rdf-0.49.1.tar.gz", hash = "sha256:86029e79e6b2a978501a51faa0ab574e9ae8eba52a9fa60cce25876b4a4f7e5e", size = 3351159, upload-time = "2025-06-25T10:01:45.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c8/38a83e8fde876fb57dce63becd33d8a2bd6dcf27760b1621545d4bf97724/apis_core_rdf-0.51.0.tar.gz", hash = "sha256:d6845887a7895f1ee341723a6d5c60ea5c005f23a29fdcfda869dc36a5ab55a5", size = 3360611, upload-time = "2025-08-13T05:44:28.463Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/21/10/290e61e550778f682127927c305ab412f48f752a31239552645e1d4a73a9/apis_core_rdf-0.49.1-py3-none-any.whl", hash = "sha256:7c966547a7e3d8c0992f7fe33275221bc97dffa817b00ecf4e54ff05a93fbd6a", size = 3321491, upload-time = "2025-06-25T10:01:42.312Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b5/31a74dda2df5d2bd5773cd733bb2ea5cf57a0dc5143a866eb83846832197/apis_core_rdf-0.51.0-py3-none-any.whl", hash = "sha256:bcdb8414c5557955f84fa11016d364a29a23cb3fa27a3dbbb2e4ef618a38593e", size = 3331736, upload-time = "2025-08-13T05:44:26.745Z" },
 ]
 
 [[package]]
@@ -103,8 +117,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apis-acdhch-default-settings", specifier = "==2.10.0" },
-    { name = "apis-core-rdf", specifier = "==0.49.1" },
+    { name = "apis-acdhch-default-settings", specifier = "==2.12.0" },
+    { name = "apis-core-rdf", specifier = "==0.51.0" },
     { name = "django-cosmograph", specifier = "==0.3.8" },
     { name = "faker", specifier = ">=37.5.3" },
     { name = "psycopg", specifier = ">=3.2.9" },
@@ -269,19 +283,6 @@ wheels = [
 ]
 
 [[package]]
-name = "crispy-bootstrap4"
-version = "2024.10"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-    { name = "django-crispy-forms" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/69/0b/6a3e2ab27d9eab3fd95628e45212454ac486b2c501def355f3c425cf4ae3/crispy-bootstrap4-2024.10.tar.gz", hash = "sha256:503e8922b0f3b5262a6fdf303a3a94eb2a07514812f1ca130b88f7c02dd25e2b", size = 35301, upload-time = "2024-10-05T15:41:50.457Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/a9/2a22c0e6b72323205a6780f9a93e8121bc2c81338d34a0ddc1f6d1a958e7/crispy_bootstrap4-2024.10-py3-none-any.whl", hash = "sha256:138a97884044ae4c4799c80595b36c42066e4e933431e2e971611e251c84f96c", size = 23060, upload-time = "2024-10-05T15:41:48.907Z" },
-]
-
-[[package]]
 name = "crispy-bootstrap5"
 version = "2025.6"
 source = { registry = "https://pypi.org/simple" }
@@ -340,6 +341,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/7f/98dd15aeed94160ef25f41bdaf363a7cf5904ca469f3dda50d56558220c3/django-allow-cidr-0.7.1.tar.gz", hash = "sha256:382c5d7a9807279e3e96e4f4892b59163a2b30128c596902bf5f80e133e1ccbb", size = 6958, upload-time = "2023-07-10T13:34:56.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/12/9b55a90a9a092a0c3a8d7aecdb5e18d9148cf6ce64aa3c3c762f533b0995/django_allow_cidr-0.7.1-py2.py3-none-any.whl", hash = "sha256:11126c5bb9df3a61ff9d97304856ba7e5b26d46c6d456709a6d9e28483bff47f", size = 4965, upload-time = "2023-07-10T13:34:54.965Z" },
+]
+
+[[package]]
+name = "django-auditlog"
+version = "3.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/46/9da1d94493832fa18d2f6324a76d387fa232001593866987a96047709f4e/django_auditlog-3.2.1.tar.gz", hash = "sha256:63a4c9f7793e94eed804bc31a04d9b0b58244b1d280e2ed273c8b406bff1f779", size = 72926, upload-time = "2025-07-03T20:08:17.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/67296d050a72dcd76f57f220df621cb27e5b9282ba7ad0f5f74870dce241/django_auditlog-3.2.1-py3-none-any.whl", hash = "sha256:99603ca9d015f7e9b062b1c34f3e0826a3ce6ae6e5950c81bb7e663f7802a899", size = 38330, upload-time = "2025-07-03T20:07:51.735Z" },
 ]
 
 [[package]]
@@ -1373,14 +1387,14 @@ wheels = [
 
 [[package]]
 name = "pydot"
-version = "4.0.1"
+version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/35/b17cb89ff865484c6a20ef46bf9d95a5f07328292578de0b295f4a6beec2/pydot-4.0.1.tar.gz", hash = "sha256:c2148f681c4a33e08bf0e26a9e5f8e4099a82e0e2a068098f32ce86577364ad5", size = 162594, upload-time = "2025-06-17T20:09:56.454Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/dd/e0e6a4fb84c22050f6a9701ad9fd6a67ef82faa7ba97b97eb6fdc6b49b34/pydot-3.0.4.tar.gz", hash = "sha256:3ce88b2558f3808b0376f22bfa6c263909e1c3981e2a7b629b65b451eee4a25d", size = 168167, upload-time = "2025-01-05T16:18:45.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/32/a7125fb28c4261a627f999d5fb4afff25b523800faed2c30979949d6facd/pydot-4.0.1-py3-none-any.whl", hash = "sha256:869c0efadd2708c0be1f916eb669f3d664ca684bc57ffb7ecc08e70d5e93fee6", size = 37087, upload-time = "2025-06-17T20:09:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/5f/1ebfd430df05c4f9e438dd3313c4456eab937d976f6ab8ce81a98f9fb381/pydot-3.0.4-py3-none-any.whl", hash = "sha256:bfa9c3fc0c44ba1d132adce131802d7df00429d1a79cc0346b0a5cd374dbe9c6", size = 35776, upload-time = "2025-01-05T16:18:42.836Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates dependency versions in the `pyproject.toml` file to ensure compatibility with the latest releases.

Dependency updates:

* Upgraded `apis-core-rdf` from version `0.49.1` to `0.51.0` to use the latest features and fixes.
* Upgraded `apis-acdhch-default-settings` from version `2.10.0` to `2.12.0` for improved settings and stability.