### PR TITLE
fix(graph): appropriate CSP settings

### DIFF
--- a/apis_ontology/settings/settings.py
+++ b/apis_ontology/settings/settings.py
@@ -11,6 +11,10 @@ ADDITIONAL_APPS = [
     "django.contrib.staticfiles",
     "django_cosmograph",
 ]
+CSP_DEFAULT_SRC = CSP_DEFAULT_SRC + (
+    "'unsafe-eval'",  # needed for cosmograph 1.4.2
+    "xovkkfhojasbjinfslpx.supabase.co",  # cosmograph telemetry
+)
 
 for app in ADDITIONAL_APPS:
     if app not in INSTALLED_APPS:


### PR DESCRIPTION
fixes #17
This pull request adds necessary configuration to the Content Security Policy (CSP) settings to support the `django_cosmograph` integration. The changes ensure that the application works correctly with Cosmograph version 1.4.2 and enables telemetry features.

CSP configuration updates:

* Updated `CSP_DEFAULT_SRC` in `settings.py` to include `'unsafe-eval'` (required for Cosmograph 1.4.2) and the Supabase telemetry domain for Cosmograph.