### PR TITLE
Core chores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.13"
 packages = [{include = "apis_ontology"}]
 dependencies = [
     "apis-core-rdf==0.62.0",
-    "apis-acdhch-default-settings==2.17.0",
+    "apis-acdhch-default-settings==2.18.0",
     "psycopg[binary]>=3.2",
     "faker>=37.5.3",
     "django-cosmograph==0.3.11",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 packages = [{include = "apis_ontology"}]
 dependencies = [
-    "apis-core-rdf==0.59.0",
+    "apis-core-rdf==0.62.0",
     "apis-acdhch-default-settings==2.17.0",
     "psycopg[binary]>=3.2",
     "faker>=37.5.3",

--- a/uv.lock
+++ b/uv.lock
@@ -89,7 +89,7 @@ wheels = [
 
 [[package]]
 name = "apis-core-rdf"
-version = "0.59.0"
+version = "0.62.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "acdh-arche-assets" },
@@ -109,9 +109,9 @@ dependencies = [
     { name = "rdflib" },
     { name = "tablib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/c5/b1f9437cb226b3e717ffcb2e5fe5e69ffccbd53f887ef27958a174f721c9/apis_core_rdf-0.59.0.tar.gz", hash = "sha256:6c1c081df2c3b400bd42a9528e64f82670f66ebf53e221b18883562f6a6bdc4a", size = 305467, upload-time = "2026-01-07T08:22:33.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/0e/09b9389622a7b382b98d8c1df41d5c84461beb69892b2511a3761004b2cc/apis_core_rdf-0.62.0.tar.gz", hash = "sha256:c53d94f12fb144824d5655404a135d62672d1ea3424b28d40c8868b2838086f8", size = 315782, upload-time = "2026-03-30T14:29:50.385Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/7b/a0a74d5c46f5f18193ee81282a6f696bd1dee209e72f67e7325e76115165/apis_core_rdf-0.59.0-py3-none-any.whl", hash = "sha256:d91b83860d7f7be15ed6cbe2cb9fcd8c8f15b26f1904e9ad65cedb81ae074983", size = 293073, upload-time = "2026-01-07T08:22:32.202Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/04/1bafbb6dbc0471d8a179b752067ac269f109cd35c966ab7c3437ec64a375/apis_core_rdf-0.62.0-py3-none-any.whl", hash = "sha256:31016e33c744891d545c85ed9bb703750bf630214c4cda587e1aabd3378e6eb3", size = 289552, upload-time = "2026-03-30T14:29:48.976Z" },
 ]
 
 [[package]]
@@ -145,7 +145,7 @@ dependencies = [
 requires-dist = [
     { name = "apis-acdhch-default-settings", specifier = "==2.17.0" },
     { name = "apis-bibsonomy", specifier = ">=0.13.2" },
-    { name = "apis-core-rdf", specifier = "==0.59.0" },
+    { name = "apis-core-rdf", specifier = "==0.62.0" },
     { name = "apis-highlighter-ng", specifier = ">=0.6.4" },
     { name = "django-cosmograph", specifier = "==0.3.11" },
     { name = "faker", specifier = ">=37.5.3" },

--- a/uv.lock
+++ b/uv.lock
@@ -29,7 +29,7 @@ wheels = [
 
 [[package]]
 name = "apis-acdhch-default-settings"
-version = "2.17.0"
+version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "apis-acdhch-django-auditlog" },
@@ -52,9 +52,9 @@ dependencies = [
     { name = "requests" },
     { name = "whitenoise" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/91/4ff3fdf8b08550db411ca504ef8d547a46f870d1ab3273673592ee0e8333/apis_acdhch_default_settings-2.17.0.tar.gz", hash = "sha256:9f9ffd9370343b789f3c36d3344f9028c5d482c207728991a2b99f759ad26626", size = 15903, upload-time = "2026-02-04T12:21:30.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/75/06fdfabdf534cc8230704dc7276d0c07ab1eb480c4b8c88b25b908c4e711/apis_acdhch_default_settings-2.18.0.tar.gz", hash = "sha256:d23d00d2ec113b71deb76722fece113a2dd53ded5cbc095883cac9f0d2d68f51", size = 16098, upload-time = "2026-02-23T12:18:49.81Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/ff/94895e6caca8b684ced6a36468104de463026ae029206dfd53e57fd29c85/apis_acdhch_default_settings-2.17.0-py3-none-any.whl", hash = "sha256:5740817ed807311f753786d07c0af46dd82028e31deffa3ddbabf16ad8ac80f2", size = 11842, upload-time = "2026-02-04T12:21:28.612Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/a1/281b77d4e68302eda36fed6d63c191d05be0c4626f4219298f40dcee03c4/apis_acdhch_default_settings-2.18.0-py3-none-any.whl", hash = "sha256:f0834907e4a49877007b6e89275a7b537397f213d9a116bebe42c119f94f56c2", size = 11997, upload-time = "2026-02-23T12:18:48.626Z" },
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apis-acdhch-default-settings", specifier = "==2.17.0" },
+    { name = "apis-acdhch-default-settings", specifier = "==2.18.0" },
     { name = "apis-bibsonomy", specifier = ">=0.13.2" },
     { name = "apis-core-rdf", specifier = "==0.62.0" },
     { name = "apis-highlighter-ng", specifier = ">=0.6.4" },


### PR DESCRIPTION
This pull request updates two dependencies in the `pyproject.toml` file to newer versions.

Dependency updates:

* Upgraded `apis-core-rdf` from version `0.59.0` to `0.62.0` to incorporate recent improvements and fixes.
* Upgraded `apis-acdhch-default-settings` from version `2.17.0` to `2.18.0` for the latest default settings.