### PR TITLE
chore(deps): bump search

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -9,11 +9,11 @@ from apis_core.apis_entities.models import AbstractEntity
 from apis_core.generic.abc import GenericModel
 from apis_core.history.models import VersionMixin
 from apis_core.relations.models import Relation
-from apis_core.search.registry import register as search_registry_register
+from apis_core.search.registry import search
 from apis_ontology.fields import AlternativeLabelsField
 
 
-@search_registry_register
+@search.register
 class Profession(GenericModel, models.Model):
     """A model representing a profession or occupation."""
 
@@ -26,7 +26,7 @@ class Profession(GenericModel, models.Model):
         ordering = ["name"]
 
 
-@search_registry_register
+@search.register
 class Person(VersionMixin, E21_Person, AbstractEntity):
     """A model representing a person with associated professions."""
 
@@ -39,7 +39,7 @@ class Person(VersionMixin, E21_Person, AbstractEntity):
         ordering = ["surname"]
 
 
-@search_registry_register
+@search.register
 class Place(VersionMixin, E53_Place, AbstractEntity):
     """A model representing a place or location."""
 
@@ -51,7 +51,7 @@ class Place(VersionMixin, E53_Place, AbstractEntity):
         ordering = ["label"]
 
 
-@search_registry_register
+@search.register
 class Group(VersionMixin, E74_Group, AbstractEntity):
     """A model representing a group or organization or institution."""
 
@@ -59,7 +59,7 @@ class Group(VersionMixin, E74_Group, AbstractEntity):
         ordering = ["label"]
 
 
-@search_registry_register
+@search.register
 class IsRelatedTo(Relation):
     """A relation indicating a familial relationship between two persons."""
 
@@ -74,7 +74,7 @@ class IsRelatedTo(Relation):
         ordering = ["pk"]
 
 
-@search_registry_register
+@search.register
 class IsAMemberOf(Relation):
     """A relation indicating that a person is a member of a group."""
 
@@ -89,7 +89,7 @@ class IsAMemberOf(Relation):
         ordering = ["pk"]
 
 
-@search_registry_register
+@search.register
 class WorksFor(Relation):
     """A relation indicating that a person works for a group or organization."""
 
@@ -104,7 +104,7 @@ class WorksFor(Relation):
         ordering = ["pk"]
 
 
-@search_registry_register
+@search.register
 class LivesIn(Relation):
     """A relation indicating that a person lives in a place."""
 

--- a/uv.lock
+++ b/uv.lock
@@ -90,7 +90,7 @@ wheels = [
 [[package]]
 name = "apis-core-rdf"
 version = "0.63.1"
-source = { git = "https://github.com/acdh-oeaw/apis-core-rdf.git?rev=birger%2Fsearch#1a8739fa58a893d721e771b451597de1f644e56a" }
+source = { git = "https://github.com/acdh-oeaw/apis-core-rdf.git?rev=birger%2Fsearch#93bf5237277d79306e91fe16548e468a71151987" }
 dependencies = [
     { name = "acdh-arche-assets" },
     { name = "crispy-bootstrap5" },


### PR DESCRIPTION
This pull request updates the way models are registered with the search system in `apis_ontology/models.py`. Instead of using the old `@search_registry_register` decorator, all relevant models now use the new `@search.register` decorator for consistency and alignment with the updated search registry API.

**Search registry integration:**

* Replaced all instances of `@search_registry_register` with `@search.register` for the following models: `Profession`, `Person`, `Place`, `Group`, `IsRelatedTo`, `IsAMemberOf`, `WorksFor`, and `LivesIn` to use the updated search registration method. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L12-R16) [[2]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L29-R29) [[3]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L42-R42) [[4]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L54-R62) [[5]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L77-R77) [[6]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L92-R92) [[7]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L107-R107)