### PR TITLE
fix(experimental): disable server side cursors

### DIFF
--- a/apis_ontology/settings/settings.py
+++ b/apis_ontology/settings/settings.py
@@ -32,3 +32,5 @@ APIS_BIBSONOMY = [
         "group": "297412",
     }
 ]
+
+DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True


### PR DESCRIPTION
based on https://docs.djangoproject.com/en/6.0/ref/databases/#:~:text=One%20solution%20is%20to%20disable,that%20use%20server%2Dside%20cursors.

> Server-side cursors[¶](https://docs.djangoproject.com/en/6.0/ref/databases/#server-side-cursors)
When using [QuerySet.iterator()](https://docs.djangoproject.com/en/6.0/ref/models/querysets/#django.db.models.query.QuerySet.iterator), Django opens a [server-side cursor](https://www.psycopg.org/psycopg3/docs/advanced/cursors.html#server-side-cursors). By default, PostgreSQL assumes that only the first 10% of the results of cursor queries will be fetched. The query planner spends less time planning the query and starts returning results faster, but this could diminish performance if more than 10% of the results are retrieved. PostgreSQL’s assumptions on the number of rows retrieved for a cursor query is controlled with the [cursor_tuple_fraction](https://www.postgresql.org/docs/current/runtime-config-query.html#GUC-CURSOR-TUPLE-FRACTION) option.
> Transaction pooling and server-side cursors[¶](https://docs.djangoproject.com/en/6.0/ref/databases/#transaction-pooling-and-server-side-cursors)
> Using a connection pooler in transaction pooling mode (e.g. [PgBouncer](https://www.pgbouncer.org/)) requires disabling server-side cursors for that connection.
> 
> Server-side cursors are local to a connection and remain open at the end of a transaction when [AUTOCOMMIT](https://docs.djangoproject.com/en/6.0/ref/settings/#std-setting-DATABASE-AUTOCOMMIT) is True. A subsequent transaction may attempt to fetch more results from a server-side cursor. In transaction pooling mode, there’s no guarantee that subsequent transactions will use the same connection. If a different connection is used, an error is raised when the transaction references the server-side cursor, because server-side cursors are only accessible in the connection in which they were created.
> One solution is to disable server-side cursors for a connection in [DATABASES](https://docs.djangoproject.com/en/6.0/ref/settings/#std-setting-DATABASES) by setting [DISABLE_SERVER_SIDE_CURSORS](https://docs.djangoproject.com/en/6.0/ref/settings/#std-setting-DATABASE-DISABLE_SERVER_SIDE_CURSORS) to True.
> To benefit from server-side cursors in transaction pooling mode, you could set up [another connection to the database](https://docs.djangoproject.com/en/6.0/topics/db/multi-db/) in order to perform queries that use server-side cursors. This connection needs to either be directly to the database or to a connection pooler in session pooling mode.
> Another option is to wrap each QuerySet using server-side cursors in an [atomic()](https://docs.djangoproject.com/en/6.0/topics/db/transactions/#django.db.transaction.atomic) block, because it disables autocommit for the duration of the transaction. This way, the server-side cursor will only live for the duration of the transaction.